### PR TITLE
revert(ci): use Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 env:
-  PYTHON_VERSION: '3.11'
+  PYTHON_VERSION: '3.10'
 
 jobs:
   test:

--- a/.pylintrc
+++ b/.pylintrc
@@ -84,7 +84,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.11
+py-version=3.10
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -19,7 +19,7 @@ rule_settings:
     - refactoring
     - suggestion
     - comment
-  python_version: "3.11"
+  python_version: "3.10"
 
 metrics:
   quality_threshold: 25.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,11 @@ If you find a bug or if something is missing in the source code, you can help us
 
 ## Getting ready to contribute
 
-For **incendium** we rely on Python 3.11 to run tests and style checks with `pre-commit` and `tox`.
+For **incendium** we rely on Python 3.10 to run tests and style checks with `pre-commit` and `tox`.
 
 ### Setting up your local environment
 
-1. Install Python 3.11
+1. Install Python 3.10
 1. Install the tools
 
     1. [`pre-commit`](https://pre-commit.com/)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py311
+    py310
 
 [testenv]
 description = run static analysis and style check


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [commit message format](/thecesrom/incendium-project/blob/HEAD/CONTRIBUTING.md#commit-message-format)
- [ ] All `tox` tests have succeeded

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Revert

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We are using Python 3.11 for tox/CI.

Issue Number: N/A

## What is the new behavior?
<!-- Please describe the new behavior. -->
We will revert back to Python 3.10, as `typed-ast` is not supported in 3.11.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Refs: 4ac0840